### PR TITLE
fix: initialize slider when DOM is already ready

### DIFF
--- a/includes/blocks/slider/frontend.js.php
+++ b/includes/blocks/slider/frontend.js.php
@@ -45,11 +45,19 @@ $slider_options = apply_filters(
 
 ob_start();
 ?>
-window.addEventListener("DOMContentLoaded", function(){
-	var swiper = new Swiper( "<?php echo esc_attr( $selector ); ?>",
-		<?php echo wp_json_encode( $slider_options ); ?>
-	);
-});
+( function() {
+	function uagbInitSlider() {
+		var swiper = new Swiper( "<?php echo esc_attr( $selector ); ?>",
+			<?php echo wp_json_encode( $slider_options ); ?>
+		);
+	}
+
+	if ( "loading" === document.readyState ) {
+		document.addEventListener( "DOMContentLoaded", uagbInitSlider );
+	} else {
+		uagbInitSlider();
+	}
+} )();
 
 <?php
 


### PR DESCRIPTION
## Summary
- replace the slider block's nested `DOMContentLoaded` listener with a ready-state aware initializer
- keep the Swiper variable scoped inside an IIFE
- allow the generated frontend script to initialize whether it is wrapped by the post-assets loader or executed after DOM readiness

## Test plan
- php -l /tmp/wp-spectra-slider-frontend.patched.php
- git diff --no-index --check /tmp/wp-spectra-slider-frontend.orig.php /tmp/wp-spectra-slider-frontend.patched.php

Fixes #52
