### PR TITLE
fix(filter): rename uag_font_disaply filter to uag_font_display

### DIFF
--- a/classes/class-uagb-post-assets.php
+++ b/classes/class-uagb-post-assets.php
@@ -1044,7 +1044,15 @@ class UAGB_Post_Assets {
 			$extra_attr .= '&subset=latin';
 		}
 
-		$display = apply_filters( 'uag_font_disaply', 'fallback' );
+		$display = apply_filters_deprecated( 'uag_font_disaply', 'fallback' );
+
+		/**
+		 * Filters the font display query parameter.
+		 *
+		 * @see https://developers.google.com/fonts/docs/getting_started#use_font-display
+		 * @param string $display The global post.
+		 */
+		$display = apply_filters( 'uag_font_display', $display );
 
 		if ( ! empty( $display ) ) {
 			$extra_attr .= '&display=' . $display;

--- a/classes/class-uagb-post-assets.php
+++ b/classes/class-uagb-post-assets.php
@@ -1044,7 +1044,7 @@ class UAGB_Post_Assets {
 			$extra_attr .= '&subset=latin';
 		}
 
-		$display = apply_filters_deprecated( 'uag_font_disaply', 'fallback' );
+		$display = apply_filters_deprecated( 'uag_font_disaply', array( 'fallback' ), '2.21.0', 'uag_font_display' );
 
 		/**
 		 * Filters the font display query parameter.


### PR DESCRIPTION
## What
Renames the misspelled filter `uag_font_disaply` to the correctly spelled `uag_font_display` in `classes/class-uagb-post-assets.php`, while keeping backward compatibility for existing filter consumers via `apply_filters_deprecated()`.

## Why
The filter name has a typo (`disaply` instead of `display`), which is easy to miss when hooking into it and inconsistent with the rest of the plugin's naming (e.g. Google Fonts `display` query parameter it controls).

## How
- Introduced the new `uag_font_display` filter as the primary hook.
- Kept the old `uag_font_disaply` name working through `apply_filters_deprecated()` so existing integrations don't break silently.
